### PR TITLE
Clean before measuring performance

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/UpdateJournal.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/UpdateJournal.kt
@@ -53,6 +53,8 @@ abstract class UpdateJournal : DefaultTask() {
 
     init {
         outputs.upToDateWhen { false }
+        val cleanTask = project.tasks.getByName("clean")
+        this.dependsOn(cleanTask)
     }
 
     @TaskAction


### PR DESCRIPTION
In this PR we make the `UpdateJournal` task depend on `clean`. Now, even if the project has been recently built, the time measurement will not be corrupted by the Gradle caches.