### PR TITLE
Improve `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,5 +108,5 @@ pubspec.lock
 # Ignore `settings.gradle.kts` after creation at the usage sites.
 settings.gradle.kts
 
-# Ignore `_out` directory containing log files.
+# Ignore `_out` directory containing log files from being visible at usage sites.
 _out

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,9 @@ pubspec.lock
 
 # Ignore the `tmp` directory used for building dependant repositories.
 /tmp
+
+# Ignore `settings.gradle.kts` after creation at the usage sites.
+settings.gradle.kts
+
+# Ignore `_out` directory containing log files.
+_out


### PR DESCRIPTION
This PR extends `.gitignore` to avoid temporary files from being visible as changes in the projects that apply `BuildSpeed` as a submodule.
