### PR TITLE
Add missing `group` and `version` properties

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,9 @@ buildscript {
     }
 }
 
+group = "io.spine.tools.tests"
+version = "1.0.0-SNAPSHOT"
+
 plugins {
     java
     kotlin("jvm")


### PR DESCRIPTION
This PR adds missing `group` and `version` properties in the project build script so that it satisfy new ToolBase API, which does not allow empty values of these project properties.
